### PR TITLE
"fixing" a potential bug where file is written to disk after each json file is read causing extreme slowness

### DIFF
--- a/src/main/scala/gov/nasa/jpl/covid19_textmining_kaggle/covid19_knowledge_graph.scala
+++ b/src/main/scala/gov/nasa/jpl/covid19_textmining_kaggle/covid19_knowledge_graph.scala
@@ -58,20 +58,21 @@ object covid19_knowledge_graph {
             model.expandPrefix("schema:text")), section.get("text").asInstanceOf[String], "en")
         }
       }
-      val outFile = new BufferedWriter(new FileWriter(new File("covid19_knowledge_graph.ttl")))
-      RDFDataMgr.write(outFile, model, org.apache.jena.riot.RDFFormat.TURTLE_PRETTY)
-      outFile.close()
     }
+    val outFile = new BufferedWriter(new FileWriter(new File("covid19_knowledge_graph.ttl")))
+    RDFDataMgr.write(outFile, model, org.apache.jena.riot.RDFFormat.TURTLE_PRETTY)
+    outFile.close()
+  }
 
-    def loadJSON(file: File): Option[JSONObject] = {
-      val parser = new JSONParser
-      try Some(parser.parse(new FileReader(file)).asInstanceOf[JSONObject])
-      catch {
-        case e: Exception =>
-          println(s"ERROR: $file: ${e.getMessage}")
-          None
-      }
+  def loadJSON(file: File): Option[JSONObject] = {
+    val parser = new JSONParser
+    try Some(parser.parse(new FileReader(file)).asInstanceOf[JSONObject])
+    catch {
+      case e: Exception =>
+        println(s"ERROR: $file: ${e.getMessage}")
+        None
     }
+  }
 //
 //    def executeWikidataDescriptionQuery(label: String): Literal = {
 //      val query = getWikidataDescriptionQuery(label)
@@ -119,6 +120,6 @@ object covid19_knowledge_graph {
 //        }
 //      }
 //    }
-  }
+  
 }
 


### PR DESCRIPTION
When I was running the 

```shell
$ sbt
> run /home/user/comm_use_subset
```
I noticed that it was creating a bunch of disk write activity which i tracked down to this. It was basically re-writing the `covid19_knowledge_graph.ttl` after each json file. I moved the write operation outside the for loop. This speeds up the processing 1000%

p.s. sorry for the updates, I keep hitting shift return for line breaks like you do slack.